### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -3,6 +3,9 @@
 
 name: .NET CI Workflow
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/jldsilva/InvoiceReminder/security/code-scanning/1](https://github.com/jldsilva/InvoiceReminder/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to build and test the .NET project. This change ensures that the workflow does not inherit unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
