### PR TITLE
Unit Tests fix

### DIFF
--- a/InvoiceReminder.API.UnitTests/Endpoints/InvoiceEndpointsTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/InvoiceEndpointsTests.cs
@@ -183,7 +183,7 @@ public sealed class InvoiceEndpointsTests
     }
 
     [TestMethod]
-    public async Task GetInvoiceById_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
+    public async Task GetInvoiceById_WhenUserIsAuthenticatedButServiceFails_ShouldReturnBadRequest()
     {
         // Arrange
         var id = Guid.NewGuid();
@@ -191,6 +191,31 @@ public sealed class InvoiceEndpointsTests
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
 
         _ = _invoiceAppService.GetByIdAsync(Arg.Any<Guid>()).ThrowsAsync<ArgumentException>();
+
+        _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+            Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(Task.FromResult(AuthorizationResult.Success()));
+
+        // Act
+        var response = await _client.SendAsync(request);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+        // Assert
+        _ = _invoiceAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        _ = result.ShouldNotBeNull();
+        _ = result.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [TestMethod]
+    public async Task GetInvoiceById_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/invoice/{id}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
+
+        _ = _invoiceAppService.GetByIdAsync(Arg.Any<Guid>()).ThrowsAsync<ApplicationException>();
 
         _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
             Arg.Any<IEnumerable<IAuthorizationRequirement>>())
@@ -290,7 +315,7 @@ public sealed class InvoiceEndpointsTests
     }
 
     [TestMethod]
-    public async Task GetInvoiceByBarcode_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
+    public async Task GetInvoiceByBarcode_WhenUserIsAuthenticatedButServiceFails_ShouldReturnBadRequest()
     {
         // Arrange
         var value = "12345678901234567890123456789012345678901234";
@@ -298,6 +323,31 @@ public sealed class InvoiceEndpointsTests
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
 
         _ = _invoiceAppService.GetByBarcodeAsync(Arg.Any<string>()).ThrowsAsync<ArgumentException>();
+
+        _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+            Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(Task.FromResult(AuthorizationResult.Success()));
+
+        // Act
+        var response = await _client.SendAsync(request);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+        // Assert
+        _ = _invoiceAppService.Received(1).GetByBarcodeAsync(Arg.Any<string>());
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        _ = result.ShouldNotBeNull();
+        _ = result.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [TestMethod]
+    public async Task GetInvoiceByBarcode_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
+    {
+        // Arrange
+        var value = "12345678901234567890123456789012345678901234";
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/invoice/get_by_barcode/{value}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
+
+        _ = _invoiceAppService.GetByBarcodeAsync(Arg.Any<string>()).ThrowsAsync<ApplicationException>();
 
         _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
             Arg.Any<IEnumerable<IAuthorizationRequirement>>())

--- a/InvoiceReminder.API.UnitTests/Endpoints/ScanEmailDefinitionEndpointsTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/ScanEmailDefinitionEndpointsTests.cs
@@ -183,6 +183,31 @@ public sealed class ScanEmailDefinitionEndpointsTests
     }
 
     [TestMethod]
+    public async Task GetScanEmailDefinitionById_WhenUserIsAuthenticatedButServiceFails_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/scan_email/{id}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
+
+        _ = _scanEmailDefinitionAppService.GetByIdAsync(Arg.Any<Guid>()).ThrowsAsync<ArgumentException>();
+
+        _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+            Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(Task.FromResult(AuthorizationResult.Success()));
+
+        // Act
+        var response = await _client.SendAsync(request);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+        // Assert
+        _ = _scanEmailDefinitionAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        _ = result.ShouldNotBeNull();
+        _ = result.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [TestMethod]
     public async Task GetScanEmailDefinitionById_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
     {
         // Arrange
@@ -190,8 +215,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
         var request = new HttpRequestMessage(HttpMethod.Get, $"/api/scan_email/{id}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
 
-        _ = _scanEmailDefinitionAppService.GetByIdAsync(Arg.Any<Guid>())
-            .ThrowsAsync(new ArgumentException("Service error"));
+        _ = _scanEmailDefinitionAppService.GetByIdAsync(Arg.Any<Guid>()).ThrowsAsync<ApplicationException>();
 
         _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
             Arg.Any<IEnumerable<IAuthorizationRequirement>>())
@@ -298,6 +322,31 @@ public sealed class ScanEmailDefinitionEndpointsTests
     }
 
     [TestMethod]
+    public async Task GetScanEmailDefinitionByUserId_WhenUserIsAuthenticatedButServiceFails_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/scan_email/get_by_user_id/{id}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
+
+        _ = _scanEmailDefinitionAppService.GetByUserIdAsync(Arg.Any<Guid>()).ThrowsAsync<ArgumentException>();
+
+        _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+            Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(Task.FromResult(AuthorizationResult.Success()));
+
+        // Act
+        var response = await _client.SendAsync(request);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+        // Assert
+        _ = _scanEmailDefinitionAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        _ = result.ShouldNotBeNull();
+        _ = result.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [TestMethod]
     public async Task GetScanEmailDefinitionByUserId_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
     {
         // Arrange
@@ -305,8 +354,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
         var request = new HttpRequestMessage(HttpMethod.Get, $"/api/scan_email/get_by_user_id/{id}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
 
-        _ = _scanEmailDefinitionAppService.GetByUserIdAsync(Arg.Any<Guid>())
-            .ThrowsAsync(new ArgumentException("Service error"));
+        _ = _scanEmailDefinitionAppService.GetByUserIdAsync(Arg.Any<Guid>()).ThrowsAsync<ApplicationException>();
 
         _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
             Arg.Any<IEnumerable<IAuthorizationRequirement>>())

--- a/InvoiceReminder.API.UnitTests/Endpoints/UserEndpointsTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/UserEndpointsTests.cs
@@ -180,6 +180,31 @@ public sealed class UserEndpointsTests
     }
 
     [TestMethod]
+    public async Task GetUserById_WhenUserIsAuthenticatedButServiceFails_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{id}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
+
+        _ = _userAppService.GetByIdAsync(Arg.Any<Guid>()).ThrowsAsync<ArgumentException>();
+
+        _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+            Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(Task.FromResult(AuthorizationResult.Success()));
+
+        // Act
+        var response = await _client.SendAsync(request);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+        // Assert
+        _ = _userAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        _ = result.ShouldNotBeNull();
+        _ = result.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [TestMethod]
     public async Task GetUserById_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
     {
         // Arrange
@@ -187,7 +212,7 @@ public sealed class UserEndpointsTests
         var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/{id}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
 
-        _ = _userAppService.GetByIdAsync(Arg.Any<Guid>()).ThrowsAsync(new ArgumentException("Service error"));
+        _ = _userAppService.GetByIdAsync(Arg.Any<Guid>()).ThrowsAsync<ApplicationException>();
 
         _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
             Arg.Any<IEnumerable<IAuthorizationRequirement>>())
@@ -288,6 +313,31 @@ public sealed class UserEndpointsTests
     }
 
     [TestMethod]
+    public async Task GetUserByEmail_WhenUserIsAuthenticatedButServiceFails_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var value = "test_user@mail_com";
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/get_by_email/{value}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
+
+        _ = _userAppService.GetByEmailAsync(Arg.Any<string>()).ThrowsAsync<ArgumentException>();
+
+        _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+            Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(Task.FromResult(AuthorizationResult.Success()));
+
+        // Act
+        var response = await _client.SendAsync(request);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+        // Assert
+        _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        _ = result.ShouldNotBeNull();
+        _ = result.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [TestMethod]
     public async Task GetUserByEmail_WhenUserIsAuthenticatedButServiceFails_ShouldReturnInternalServerError()
     {
         // Arrange
@@ -295,7 +345,7 @@ public sealed class UserEndpointsTests
         var request = new HttpRequestMessage(HttpMethod.Get, $"/api/user/get_by_email/{value}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "test_token");
 
-        _ = _userAppService.GetByEmailAsync(Arg.Any<string>()).ThrowsAsync(new ArgumentException("Service error"));
+        _ = _userAppService.GetByEmailAsync(Arg.Any<string>()).ThrowsAsync<ApplicationException>();
 
         _ = _authorizationService.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
             Arg.Any<IEnumerable<IAuthorizationRequirement>>())


### PR DESCRIPTION
Correção dos testes unitários, envolvendo cenários de falha em caso de erro 500 e erro 400.


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes unit tests to handle scenarios where the service fails, specifically returning BadRequest for certain error cases instead of InternalServerError.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant AuthService
    participant AppService

    Note over Client,AppService: Error Handling Flow for Protected Endpoints

    Client->>API: GET Request with Bearer Token
    API->>AuthService: Authorize Request
    AuthService-->>API: Authorization Success

    alt Service throws ArgumentException
        API->>AppService: Get Resource
        AppService-->>API: Throws ArgumentException
        API-->>Client: 400 Bad Request with ProblemDetails
    else Service throws ApplicationException
        API->>AppService: Get Resource
        AppService-->>API: Throws ApplicationException
        API-->>Client: 500 Internal Server Error with ProblemDetails
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/9/files#diff-4f286bd81bba5149c39cfa49cead33f53800d855d45214b1a79eb1ea3bbbe8e2>InvoiceReminder.API.UnitTests/Endpoints/InvoiceEndpointsTests.cs</a></td><td>Updated tests to return BadRequest for service failures instead of InternalServerError.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/9/files#diff-3e4ef368e4eba1ab0732ebd78c762db72676a1c7d268fe37a30006c9abfda2ae>InvoiceReminder.API.UnitTests/Endpoints/JobScheduleEndPointsTests.cs</a></td><td>Modified tests to return BadRequest for service failures instead of InternalServerError.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/9/files#diff-288525efb79c7920a1aa550c7a270e35f198f1723ea1bf32c0a6cf4961aa9dad>InvoiceReminder.API.UnitTests/Endpoints/ScanEmailDefinitionEndpointsTests.cs</a></td><td>Adjusted tests to return BadRequest for service failures instead of InternalServerError.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/9/files#diff-ccc4f49a830cf38b7e3256df61bb4684a1cac5d1d1161cca1df07375ff77bd06>InvoiceReminder.API.UnitTests/Endpoints/UserEndpointsTests.cs</a></td><td>Changed tests to return BadRequest for service failures instead of InternalServerError.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.cs`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


