### PR TITLE
MSTest package reference

### DIFF
--- a/InvoiceReminder.API.UnitTests/InvoiceReminder.API.UnitTests.csproj
+++ b/InvoiceReminder.API.UnitTests/InvoiceReminder.API.UnitTests.csproj
@@ -22,16 +22,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Shouldly" Version="4.3.0" />
-
-    <!--<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
-    <PackageReference Include="MSTest.Analyzers" Version="3.8.3">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>-->
   </ItemGroup>
 
   <ItemGroup>
@@ -40,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -48,22 +38,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.Analyzers" Version="3.8.3">
+    <PackageReference Update="MSTest.Analyzers" Version="3.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.Application.UnitTests/InvoiceReminder.Application.UnitTests.csproj
+++ b/InvoiceReminder.Application.UnitTests/InvoiceReminder.Application.UnitTests.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,22 +35,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.Analyzers" Version="3.8.3">
+    <PackageReference Update="MSTest.Analyzers" Version="3.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.ArchitectureTests/InvoiceReminder.ArchitectureTests.csproj
+++ b/InvoiceReminder.ArchitectureTests/InvoiceReminder.ArchitectureTests.csproj
@@ -18,22 +18,37 @@
   </ItemGroup>
 
   <ItemGroup>
-
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
-
-    <PackageReference Include="MSTest.Analyzers" Version="3.9.3" />
-
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <ProjectReference Include="..\InvoiceReminder.API\InvoiceReminder.API.csproj" />
     <ProjectReference Include="..\InvoiceReminder.Application\InvoiceReminder.Application.csproj" />
     <ProjectReference Include="..\InvoiceReminder.Data\InvoiceReminder.Data.csproj" />
     <ProjectReference Include="..\InvoiceReminder.Domain\InvoiceReminder.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="MSTest.Analyzers" Version="3.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="MSTest.TestAdapter" Version="3.9.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.DomainEntities.UnitTests/InvoiceReminder.DomainEntities.UnitTests.csproj
+++ b/InvoiceReminder.DomainEntities.UnitTests/InvoiceReminder.DomainEntities.UnitTests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,22 +33,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.Analyzers" Version="3.8.3">
+    <PackageReference Update="MSTest.Analyzers" Version="3.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.ExternalServices.UnitTests/InvoiceReminder.ExternalServices.UnitTests.csproj
+++ b/InvoiceReminder.ExternalServices.UnitTests/InvoiceReminder.ExternalServices.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk/3.6.4">
+﻿<Project Sdk="MSTest.Sdk/3.6.4">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,22 +37,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.Analyzers" Version="3.8.3">
+    <PackageReference Update="MSTest.Analyzers" Version="3.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.Infrastructure.UnitTests/InvoiceReminder.Infrastructure.UnitTests.csproj
+++ b/InvoiceReminder.Infrastructure.UnitTests/InvoiceReminder.Infrastructure.UnitTests.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,22 +39,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.Analyzers" Version="3.8.3">
+    <PackageReference Update="MSTest.Analyzers" Version="3.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.JobScheduler.UnitTests/InvoiceReminder.JobScheduler.UnitTests.csproj
+++ b/InvoiceReminder.JobScheduler.UnitTests/InvoiceReminder.JobScheduler.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk/3.6.4">
+﻿<Project Sdk="MSTest.Sdk/3.6.4">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,22 +21,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.Analyzers" Version="3.8.3">
+    <PackageReference Update="MSTest.Analyzers" Version="3.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Corrigindo referência de versão dos pacotes relacionados ao framework de testes.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the version references for MSTest packages across multiple unit test projects.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant AT as Architecture Tests
    participant Tests as Test Projects
    
    PR->>AT: Add Project References
    Note over AT: Added references to:<br/>API, Application,<br/>Data, Domain projects
    
    PR->>Tests: Update Test Packages
    Note over Tests: Updated versions for:<br/>Microsoft.NET.Test.Sdk (17.14.1)<br/>MSTest.* packages (3.9.3)<br/>TrxReport (1.7.3)
    
    PR->>Tests: Update Project SDK
    Note over Tests: Changed to MSTest.Sdk/3.6.4<br/>for some test projects
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/28/files#diff-c382cdb446bec2c9121c9796e5fafbfc327c308f0392d36ea04ef8270567f543>InvoiceReminder.API.UnitTests/InvoiceReminder.API.UnitTests.csproj</a></td><td>Updated MSTest package versions.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/28/files#diff-1656d7aaa44de9cc67d628c82ef689f7c81516c5659509dfbcd8d9252bccfed3>InvoiceReminder.Application.UnitTests/InvoiceReminder.Application.UnitTests.csproj</a></td><td>Updated MSTest package versions.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/28/files#diff-7e7756f90824c94b4d025eef680bd40ce0cc83b07093ec2a990fbe70bc5d9a88>InvoiceReminder.ArchitectureTests/InvoiceReminder.ArchitectureTests.csproj</a></td><td>Updated MSTest package versions and added project references.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/28/files#diff-48ec33bc4ea294dae1d4bd9da0b064c092e8edeb4c2676fa1abeb5706a0f87f3>InvoiceReminder.DomainEntities.UnitTests/InvoiceReminder.DomainEntities.UnitTests.csproj</a></td><td>Updated MSTest package versions.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/28/files#diff-bdd84219f5fdc43b17a31f8f45bb3df6acab72c5a4bef613691e0a850a7ecdd3>InvoiceReminder.ExternalServices.UnitTests/InvoiceReminder.ExternalServices.UnitTests.csproj</a></td><td>Updated MSTest package versions.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/28/files#diff-ee8889832ac9d1a1a5a345f5046138b41e49c92c58ba696e0d6c5ecc19dd52af>InvoiceReminder.Infrastructure.UnitTests/InvoiceReminder.Infrastructure.UnitTests.csproj</a></td><td>Updated MSTest package versions.</td></tr>
<tr><td><a href=https://github.com/jldsilva/InvoiceReminder/pull/28/files#diff-a2b8b0a07e15c8da2748c6aa17880cd31d4478ca18620f74b5c1c09dded61141>InvoiceReminder.JobScheduler.UnitTests/InvoiceReminder.JobScheduler.UnitTests.csproj</a></td><td>Updated MSTest package versions.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.csproj`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Atualização das versões dos pacotes de teste (MSTest, Microsoft.NET.Test.Sdk, Microsoft.Testing.Extensions.TrxReport) em múltiplos projetos de testes.
  * Melhoria na organização das referências em arquivos de configuração dos projetos de testes.
  * Nenhuma alteração funcional ou estrutural nos testes existentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->