### PR TITLE
Uses central package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,63 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  
+  <ItemGroup>
+	<PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
+	<PackageVersion Include="Google.Apis.Gmail.v1" Version="1.70.0.3833" />
+	<PackageVersion Include="Dapper" Version="2.1.66" />
+	<PackageVersion Include="EFCore.BulkExtensions" Version="9.0.1" />
+	<PackageVersion Include="EFCore.BulkExtensions.PostgreSql" Version="9.0.1" />
+	<PackageVersion Include="itext" Version="9.2.0" />
+	<PackageVersion Include="itext.bouncy-castle-adapter" Version="9.2.0" />
+	<PackageVersion Include="itext.bouncy-castle-fips-adapter" Version="9.2.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+	<PackageVersion Include="Mapster" Version="7.4.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+	<PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.8" />
+	<PackageVersion Include="Npgsql" Version="9.0.3" />
+	<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+	<PackageVersion Include="Quartz" Version="3.15.0" />
+	<PackageVersion Include="Scalar.AspNetCore" Version="2.6.8" />
+	<PackageVersion Include="Scrutor" Version="6.1.0" />
+	<PackageVersion Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+	<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
+	<PackageVersion Include="Telegram.Bot" Version="22.6.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+	<PackageVersion Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.3.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
+	<PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+	<PackageVersion Include="NSubstitute" Version="5.3.0" />
+	<PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+	<PackageVersion Include="Shouldly" Version="4.3.0" />
+	<PackageVersion Include="System.CodeDom" Version="9.0.8" />
+  </ItemGroup>
+  
+  <ItemGroup>
+	<PackageVersion Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
+	<PackageVersion Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
+	<PackageVersion Update="MSTest.Analyzers" Version="3.10.1" />
+	<PackageVersion Update="MSTest.TestAdapter" Version="3.10.1" />
+	<PackageVersion Update="MSTest.TestFramework" Version="3.10.1" />
+  </ItemGroup>
+</Project>

--- a/InvoiceReminder.API.UnitTests/InvoiceReminder.API.UnitTests.csproj
+++ b/InvoiceReminder.API.UnitTests/InvoiceReminder.API.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/3.10.1">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -19,27 +19,25 @@
   </ItemGroup>  
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.14.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
-    <PackageReference Update="MSTest.Analyzers" Version="3.10.1">
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="MSTest.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.10.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Update="MSTest.TestAdapter" />
+    <PackageReference Update="MSTest.TestFramework" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.API/InvoiceReminder.API.csproj
+++ b/InvoiceReminder.API/InvoiceReminder.API.csproj
@@ -15,17 +15,17 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.6.8" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Scalar.AspNetCore" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/InvoiceReminder.Application.UnitTests/InvoiceReminder.Application.UnitTests.csproj
+++ b/InvoiceReminder.Application.UnitTests/InvoiceReminder.Application.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/3.10.1">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -18,25 +18,23 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.14.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Update="MSTest.Analyzers" Version="3.10.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.10.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Update="MSTest.TestAdapter" />
+    <PackageReference Update="MSTest.TestFramework" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.Application/InvoiceReminder.Application.csproj
+++ b/InvoiceReminder.Application/InvoiceReminder.Application.csproj
@@ -21,16 +21,16 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Mapster" Version="7.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Quartz" Version="3.15.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Mapster" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Quartz" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.ArchitectureTests/InvoiceReminder.ArchitectureTests.csproj
+++ b/InvoiceReminder.ArchitectureTests/InvoiceReminder.ArchitectureTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/3.10.1">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -20,21 +20,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.14.1" />
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="NetArchTest.Rules" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
-    <PackageReference Update="MSTest.Analyzers" Version="3.10.1">
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="MSTest.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.10.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Update="MSTest.TestAdapter" />
+    <PackageReference Update="MSTest.TestFramework" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.Authentication/InvoiceReminder.Authentication.csproj
+++ b/InvoiceReminder.Authentication/InvoiceReminder.Authentication.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.8" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/InvoiceReminder.CrossCutting.IoC/InvoiceReminder.CrossCutting.IoC.csproj
+++ b/InvoiceReminder.CrossCutting.IoC/InvoiceReminder.CrossCutting.IoC.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Scrutor" Version="6.1.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Scrutor" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/InvoiceReminder.Data/InvoiceReminder.Data.csproj
+++ b/InvoiceReminder.Data/InvoiceReminder.Data.csproj
@@ -12,25 +12,25 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.66" />
-    <PackageReference Include="EFCore.BulkExtensions" Version="9.0.1" />
-    <PackageReference Include="EFCore.BulkExtensions.PostgreSql" Version="9.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="EFCore.BulkExtensions" />
+    <PackageReference Include="EFCore.BulkExtensions.PostgreSql" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/InvoiceReminder.Domain/InvoiceReminder.Domain.csproj
+++ b/InvoiceReminder.Domain/InvoiceReminder.Domain.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/InvoiceReminder.DomainEntities.UnitTests/InvoiceReminder.DomainEntities.UnitTests.csproj
+++ b/InvoiceReminder.DomainEntities.UnitTests/InvoiceReminder.DomainEntities.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/3.10.1">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -19,22 +19,20 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.14.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
-    <PackageReference Update="MSTest.Analyzers" Version="3.10.1">
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="MSTest.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.10.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Update="MSTest.TestAdapter" />
+    <PackageReference Update="MSTest.TestFramework" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.ExternalServices.UnitTests/InvoiceReminder.ExternalServices.UnitTests.csproj
+++ b/InvoiceReminder.ExternalServices.UnitTests/InvoiceReminder.ExternalServices.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/3.10.1">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -18,27 +18,25 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="itext.bouncy-castle-adapter" Version="9.2.0" />
-    <PackageReference Include="itext.bouncy-castle-fips-adapter" Version="9.2.0" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.14.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+    <PackageReference Include="itext.bouncy-castle-adapter" />
+    <PackageReference Include="itext.bouncy-castle-fips-adapter" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
-    <PackageReference Update="MSTest.Analyzers" Version="3.10.1">
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="MSTest.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.10.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Update="MSTest.TestAdapter" />
+    <PackageReference Update="MSTest.TestFramework" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.Infrastructure.UnitTests/InvoiceReminder.Infrastructure.UnitTests.csproj
+++ b/InvoiceReminder.Infrastructure.UnitTests/InvoiceReminder.Infrastructure.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/3.10.1">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -19,28 +19,26 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.14.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+    <PackageReference Include="Microsoft.EntityFrameworkCore"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
-    <PackageReference Update="MSTest.Analyzers" Version="3.10.1">
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="MSTest.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.10.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Update="MSTest.TestAdapter" />
+    <PackageReference Update="MSTest.TestFramework" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.JobScheduler.UnitTests/InvoiceReminder.JobScheduler.UnitTests.csproj
+++ b/InvoiceReminder.JobScheduler.UnitTests/InvoiceReminder.JobScheduler.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSTest.Sdk/3.10.1">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -17,25 +17,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.14.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="1.8.1" />
-    <PackageReference Update="MSTest.Analyzers" Version="3.10.1">
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Update="MSTest.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.10.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="3.10.1" />
+    <PackageReference Update="MSTest.TestAdapter" />
+    <PackageReference Update="MSTest.TestFramework" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.JobScheduler/InvoiceReminder.JobScheduler.csproj
+++ b/InvoiceReminder.JobScheduler/InvoiceReminder.JobScheduler.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageReference Include="Quartz" Version="3.15.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Quartz" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/InvoiceReminder.Services/InvoiceReminder.ExternalServices.csproj
+++ b/InvoiceReminder.Services/InvoiceReminder.ExternalServices.csproj
@@ -12,21 +12,19 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Gmail.v1" Version="1.70.0.3833" />
-    <PackageReference Include="itext" Version="9.2.0" />
-    <PackageReference Include="itext.bouncy-castle-adapter" Version="9.2.0" />
-    <PackageReference Include="itext.bouncy-castle-fips-adapter" Version="9.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
+    <PackageReference Include="Google.Apis.Gmail.v1" />
+    <PackageReference Include="itext" />
+    <PackageReference Include="itext.bouncy-castle-adapter" />
+    <PackageReference Include="itext.bouncy-castle-fips-adapter" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Telegram.Bot" Version="22.6.0" />
-    <PackageReference Include="ZXing.Net" Version="0.16.10" />
-    <PackageReference Include="ZXing.Net.Bindings.ZKWeb.System.Drawing" Version="0.16.8" />
+    <PackageReference Include="Telegram.Bot" />
   </ItemGroup>
 
 </Project>

--- a/InvoiceReminder.UnitTests.Assets/InvoiceReminder.UnitTests.Assets.csproj
+++ b/InvoiceReminder.UnitTests.Assets/InvoiceReminder.UnitTests.Assets.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk/3.10.1">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CodeDom" Version="9.0.8" />
+    <PackageReference Include="System.CodeDom" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds Directory.Packages.props to manage package versions centrally.

Removes individual PackageReference Version attributes from csproj files and references the central package versions.

This change promotes consistency and simplifies dependency management across the solution.
