### PR TITLE
Adds cancellation token to test requests

### DIFF
--- a/InvoiceReminder.API.UnitTests/Endpoints/InvoiceEndpointsTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/InvoiceEndpointsTests.cs
@@ -23,6 +23,8 @@ public sealed class InvoiceEndpointsTests
     private readonly IAuthorizationService _authorizationService;
     private readonly IInvoiceAppService _invoiceAppService;
 
+    public TestContext TestContext { get; set; }
+
     public InvoiceEndpointsTests()
     {
         var factory = new CustomWebApplicationFactory<Program>();
@@ -72,8 +74,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<IEnumerable<InvoiceViewModel>>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<IEnumerable<InvoiceViewModel>>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetAll();
@@ -94,7 +96,7 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -116,8 +118,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetAll();
@@ -154,8 +156,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -176,7 +178,7 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -197,8 +199,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -222,8 +224,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -249,8 +251,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -286,8 +288,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByBarcodeAsync(Arg.Any<string>());
@@ -308,7 +310,7 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -329,8 +331,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByBarcodeAsync(Arg.Any<string>());
@@ -354,8 +356,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByBarcodeAsync(Arg.Any<string>());
@@ -381,8 +383,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).GetByBarcodeAsync(Arg.Any<string>());
@@ -424,8 +426,8 @@ public sealed class InvoiceEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(invoiceViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).AddAsync(Arg.Any<InvoiceViewModel>());
@@ -445,7 +447,7 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -480,8 +482,8 @@ public sealed class InvoiceEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(invoiceViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).AddAsync(Arg.Any<InvoiceViewModel>());
@@ -523,8 +525,8 @@ public sealed class InvoiceEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(invoiceViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<InvoiceViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).UpdateAsync(Arg.Any<InvoiceViewModel>());
@@ -544,7 +546,7 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -578,8 +580,8 @@ public sealed class InvoiceEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(invoiceViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).UpdateAsync(Arg.Any<InvoiceViewModel>());
@@ -607,8 +609,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).RemoveAsync(Arg.Any<InvoiceViewModel>());
@@ -628,7 +630,7 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -650,8 +652,8 @@ public sealed class InvoiceEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _invoiceAppService.Received(1).RemoveAsync(Arg.Any<InvoiceViewModel>());

--- a/InvoiceReminder.API.UnitTests/Endpoints/JobScheduleEndPointsTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/JobScheduleEndPointsTests.cs
@@ -23,6 +23,8 @@ public sealed class JobScheduleEndPointsTests
     private readonly IAuthorizationService _authorizationService;
     private readonly IJobScheduleAppService _jobScheduleAppService;
 
+    public TestContext TestContext { get; set; }
+
     public JobScheduleEndPointsTests()
     {
         var factory = new CustomWebApplicationFactory<Program>();
@@ -66,8 +68,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<IEnumerable<JobScheduleViewModel>>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<IEnumerable<JobScheduleViewModel>>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetAll();
@@ -88,7 +90,7 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -110,8 +112,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetAll();
@@ -145,8 +147,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<JobScheduleViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<JobScheduleViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -167,7 +169,7 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -188,8 +190,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -213,8 +215,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -240,8 +242,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -283,8 +285,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<IEnumerable<JobScheduleViewModel>>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<IEnumerable<JobScheduleViewModel>>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -304,7 +306,7 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -325,8 +327,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -350,8 +352,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -377,8 +379,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -417,8 +419,8 @@ public sealed class JobScheduleEndPointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<JobScheduleViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<JobScheduleViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).AddNewJobAsync(Arg.Any<JobScheduleViewModel>());
@@ -438,7 +440,7 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -470,8 +472,8 @@ public sealed class JobScheduleEndPointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).AddNewJobAsync(Arg.Any<JobScheduleViewModel>());
@@ -511,8 +513,8 @@ public sealed class JobScheduleEndPointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<JobScheduleViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<JobScheduleViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).UpdateAsync(Arg.Any<JobScheduleViewModel>());
@@ -532,7 +534,7 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -564,8 +566,8 @@ public sealed class JobScheduleEndPointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).UpdateAsync(Arg.Any<JobScheduleViewModel>());
@@ -593,8 +595,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).RemoveAsync(Arg.Any<JobScheduleViewModel>());
@@ -614,7 +616,7 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -636,8 +638,8 @@ public sealed class JobScheduleEndPointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _jobScheduleAppService.Received(1).RemoveAsync(Arg.Any<JobScheduleViewModel>());

--- a/InvoiceReminder.API.UnitTests/Endpoints/LoginEndpointTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/LoginEndpointTests.cs
@@ -24,6 +24,8 @@ public class LoginEndpointTests
     private readonly IJwtProvider _jwtProvider;
     private readonly IUserAppService _userAppService;
 
+    public TestContext TestContext { get; set; }
+
     public LoginEndpointTests()
     {
         var factory = new CustomWebApplicationFactory<Program>();
@@ -65,8 +67,8 @@ public class LoginEndpointTests
 
         // Act
         request.Content = JsonContent.Create(loginRequest);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<JwtObject>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<JwtObject>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
@@ -103,8 +105,8 @@ public class LoginEndpointTests
 
         // Act
         request.Content = JsonContent.Create(loginRequest);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<JwtObject>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<JwtObject>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
@@ -148,8 +150,8 @@ public class LoginEndpointTests
 
         // Act
         request.Content = JsonContent.Create(loginRequest);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<JwtObject>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<JwtObject>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
@@ -180,8 +182,8 @@ public class LoginEndpointTests
 
         // Act
         request.Content = JsonContent.Create(loginRequest);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());

--- a/InvoiceReminder.API.UnitTests/Endpoints/ScanEmailDefinitionEndpointsTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/ScanEmailDefinitionEndpointsTests.cs
@@ -22,6 +22,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
     private readonly IAuthorizationService _authorizationService;
     private readonly IScanEmailDefinitionAppService _scanEmailDefinitionAppService;
 
+    public TestContext TestContext { get; set; }
+
     public ScanEmailDefinitionEndpointsTests()
     {
         var factory = new CustomWebApplicationFactory<Program>();
@@ -67,8 +69,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<IEnumerable<ScanEmailDefinitionViewModel>>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<IEnumerable<ScanEmailDefinitionViewModel>>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetAll();
@@ -93,7 +95,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -115,8 +117,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetAll();
@@ -153,8 +155,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -176,7 +178,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -197,8 +199,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -222,8 +224,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -249,8 +251,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -294,8 +296,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<IEnumerable<ScanEmailDefinitionViewModel>>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<IEnumerable<ScanEmailDefinitionViewModel>>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -315,7 +317,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -336,8 +338,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -361,8 +363,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -389,8 +391,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetByUserIdAsync(Arg.Any<Guid>());
@@ -429,8 +431,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetBySenderEmailAddressAsync(Arg.Any<string>(), Arg.Any<Guid>());
@@ -450,7 +452,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -473,8 +475,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetBySenderEmailAddressAsync(Arg.Any<string>(), Arg.Any<Guid>());
@@ -503,8 +505,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).GetBySenderEmailAddressAsync(Arg.Any<string>(), Arg.Any<Guid>());
@@ -545,8 +547,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).AddAsync(Arg.Any<ScanEmailDefinitionViewModel>());
@@ -566,7 +568,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -601,8 +603,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).AddAsync(Arg.Any<ScanEmailDefinitionViewModel>());
@@ -644,8 +646,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ScanEmailDefinitionViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).UpdateAsync(Arg.Any<ScanEmailDefinitionViewModel>());
@@ -665,7 +667,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -699,8 +701,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(jobScheduleViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).UpdateAsync(Arg.Any<ScanEmailDefinitionViewModel>());
@@ -728,8 +730,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).RemoveAsync(Arg.Any<ScanEmailDefinitionViewModel>());
@@ -749,7 +751,7 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -771,8 +773,8 @@ public sealed class ScanEmailDefinitionEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _scanEmailDefinitionAppService.Received(1).RemoveAsync(Arg.Any<ScanEmailDefinitionViewModel>());

--- a/InvoiceReminder.API.UnitTests/Endpoints/UserEndpointsTests.cs
+++ b/InvoiceReminder.API.UnitTests/Endpoints/UserEndpointsTests.cs
@@ -23,6 +23,8 @@ public sealed class UserEndpointsTests
     private readonly IAuthorizationService _authorizationService;
     private readonly IUserAppService _userAppService;
 
+    public TestContext TestContext { get; set; }
+
     public UserEndpointsTests()
     {
         var factory = new CustomWebApplicationFactory<Program>();
@@ -70,8 +72,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<IEnumerable<UserViewModel>>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<IEnumerable<UserViewModel>>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetAll();
@@ -92,7 +94,7 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -114,8 +116,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetAll();
@@ -151,8 +153,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<UserViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<UserViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -173,7 +175,7 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -194,8 +196,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -219,8 +221,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -246,8 +248,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByIdAsync(Arg.Any<Guid>());
@@ -283,8 +285,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<UserViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<UserViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
@@ -306,7 +308,7 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -327,8 +329,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
@@ -352,8 +354,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
@@ -379,8 +381,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).GetByEmailAsync(Arg.Any<string>());
@@ -421,8 +423,8 @@ public sealed class UserEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(userViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<UserViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<UserViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).AddAsync(Arg.Any<UserViewModel>());
@@ -442,7 +444,7 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -476,8 +478,8 @@ public sealed class UserEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(userViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).AddAsync(Arg.Any<UserViewModel>());
@@ -525,8 +527,8 @@ public sealed class UserEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(usersViewModel);
-        var response = await _client.SendAsync(request);
-        var result = int.Parse(await response.Content.ReadAsStringAsync());
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = int.Parse(await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token));
 
         // Assert
         _ = _userAppService.Received(1).BulkInsertAsync(Arg.Any<ICollection<UserViewModel>>());
@@ -546,7 +548,7 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -591,8 +593,8 @@ public sealed class UserEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(usersViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).BulkInsertAsync(Arg.Any<ICollection<UserViewModel>>());
@@ -634,8 +636,8 @@ public sealed class UserEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(userViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<UserViewModel>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<UserViewModel>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).UpdateAsync(Arg.Any<UserViewModel>());
@@ -655,7 +657,7 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -690,8 +692,8 @@ public sealed class UserEndpointsTests
 
         // Act
         request.Content = JsonContent.Create(userViewModel);
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).UpdateAsync(Arg.Any<UserViewModel>());
@@ -719,8 +721,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadAsStringAsync();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadAsStringAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).RemoveAsync(Arg.Any<UserViewModel>());
@@ -740,7 +742,7 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Failed()));
 
         // Act
-        var response = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -762,8 +764,8 @@ public sealed class UserEndpointsTests
             .Returns(Task.FromResult(AuthorizationResult.Success()));
 
         // Act
-        var response = await _client.SendAsync(request);
-        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        var response = await _client.SendAsync(request, TestContext.CancellationTokenSource.Token);
+        var result = await response.Content.ReadFromJsonAsync<ProblemDetails>(TestContext.CancellationTokenSource.Token);
 
         // Assert
         _ = _userAppService.Received(1).RemoveAsync(Arg.Any<UserViewModel>());

--- a/InvoiceReminder.Application.UnitTests/AppServices/BaseAppServiceTests.cs
+++ b/InvoiceReminder.Application.UnitTests/AppServices/BaseAppServiceTests.cs
@@ -13,6 +13,8 @@ public class BaseAppServiceTests
     private readonly IBaseRepository<TestEntity> _repository;
     private readonly IUnitOfWork _unitOfWork;
 
+    public TestContext TestContext { get; set; }
+
     public BaseAppServiceTests()
     {
         _repository = Substitute.For<IBaseRepository<TestEntity>>();
@@ -27,7 +29,7 @@ public class BaseAppServiceTests
         var viewModel = new TestEntityViewModel { Name = "Test" };
 
         _ = _repository.AddAsync(Arg.Any<TestEntity>()).Returns(viewModel.Adapt<TestEntity>());
-        _ = _unitOfWork.SaveChangesAsync().Returns(Task.CompletedTask);
+        _ = _unitOfWork.SaveChangesAsync(TestContext.CancellationTokenSource.Token).Returns(Task.CompletedTask);
 
         // Act
         var result = await _appService.AddAsync(viewModel);
@@ -82,7 +84,7 @@ public class BaseAppServiceTests
         };
 
         _ = _repository.BulkInsertAsync(Arg.Any<ICollection<TestEntity>>()).Returns(viewModels.Count);
-        _ = _unitOfWork.SaveChangesAsync().Returns(Task.CompletedTask);
+        _ = _unitOfWork.SaveChangesAsync(TestContext.CancellationTokenSource.Token).Returns(Task.CompletedTask);
 
         // Act
         var result = await _appService.BulkInsertAsync(viewModels);
@@ -184,7 +186,7 @@ public class BaseAppServiceTests
         var entity = new TestEntityViewModel { Name = "Test" };
 
         _repository.Remove(Arg.Any<TestEntity>());
-        _ = _unitOfWork.SaveChangesAsync().Returns(Task.CompletedTask);
+        _ = _unitOfWork.SaveChangesAsync(TestContext.CancellationTokenSource.Token).Returns(Task.CompletedTask);
 
         // Act
         var result = await _appService.RemoveAsync(entity);
@@ -219,7 +221,7 @@ public class BaseAppServiceTests
         var viewModel = new TestEntityViewModel { Name = "Updated" };
 
         _ = _repository.Update(Arg.Any<TestEntity>()).Returns(viewModel.Adapt<TestEntity>());
-        _ = _unitOfWork.SaveChangesAsync().Returns(Task.CompletedTask);
+        _ = _unitOfWork.SaveChangesAsync(TestContext.CancellationTokenSource.Token).Returns(Task.CompletedTask);
 
         // Act
         var result = await _appService.UpdateAsync(viewModel);

--- a/InvoiceReminder.Application.UnitTests/AppServices/JobScheduleAppServiceTests.cs
+++ b/InvoiceReminder.Application.UnitTests/AppServices/JobScheduleAppServiceTests.cs
@@ -18,6 +18,8 @@ public sealed class JobScheduleAppServiceTests
     private readonly IJobFactory _jobFactory;
     private readonly ISchedulerFactory _schedulerFactory;
 
+    public TestContext TestContext { get; set; }
+
     public JobScheduleAppServiceTests()
     {
         _repository = Substitute.For<IJobScheduleRepository>();
@@ -53,7 +55,7 @@ public sealed class JobScheduleAppServiceTests
 
         // Assert
         _ = await _repository.DidNotReceive().AddAsync(Arg.Any<JobSchedule>());
-        await _unitOfWork.DidNotReceive().SaveChangesAsync();
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         result.ShouldSatisfyAllConditions(() =>
         {
@@ -82,7 +84,7 @@ public sealed class JobScheduleAppServiceTests
 
         // Assert
         _ = await _repository.Received(1).AddAsync(Arg.Is<JobSchedule>(x => x.Id == viewModel.Id));
-        await _unitOfWork.Received(1).SaveChangesAsync();
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
 
         result.ShouldSatisfyAllConditions(() =>
         {

--- a/InvoiceReminder.Infrastructure.UnitTests/Data/Repository/BaseRepositoryTests.cs
+++ b/InvoiceReminder.Infrastructure.UnitTests/Data/Repository/BaseRepositoryTests.cs
@@ -13,6 +13,8 @@ public class BaseRepositoryTests
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<TestDbContext> _contextOptions;
 
+    public TestContext TestContext { get; set; }
+
     public BaseRepositoryTests()
     {
         _connection = new SqliteConnection("Filename=:memory:");
@@ -51,7 +53,7 @@ public class BaseRepositoryTests
 
         // Act
         var addedEntity = await repository.AddAsync(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         addedEntity.ShouldBeSameAs(entity);
@@ -73,14 +75,14 @@ public class BaseRepositoryTests
 
         // Act
         var count = await repository.BulkInsertAsync(entities);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         count.ShouldBe(entities.Count);
 
         context.ShouldSatisfyAllConditions(() =>
         {
-            context.TestEntities.CountAsync().Result.ShouldBe(entities.Count);
+            context.TestEntities.CountAsync(TestContext.CancellationTokenSource.Token).Result.ShouldBe(entities.Count);
             context.TestEntities.ShouldAllBe(e => e.CreatedAt.HasValue && e.UpdatedAt.HasValue);
         });
 
@@ -94,12 +96,12 @@ public class BaseRepositoryTests
         using var context = CreateContext();
         var repository = new BaseRepository<TestDbContext, TestEntity>(context);
         _ = await repository.AddAsync(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
 
         // Act
         repository.Remove(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         context.TestEntities.ShouldNotContain(entity);
@@ -114,14 +116,14 @@ public class BaseRepositoryTests
         var repository = new BaseRepository<TestDbContext, TestEntity>(context);
 
         _ = await repository.AddAsync(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         _ = context.Attach(entity);
         context.Entry(entity).State = EntityState.Detached;
 
         // Act
         repository.Remove(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         // Assert
         context.TestEntities.ShouldNotContain(entity);
@@ -136,7 +138,7 @@ public class BaseRepositoryTests
         var repository = new BaseRepository<TestDbContext, TestEntity>(context);
 
         _ = await repository.AddAsync(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         // Act
         var retrievedEntity = await repository.GetByIdAsync(entity.Id);
@@ -178,7 +180,7 @@ public class BaseRepositoryTests
         using var context = CreateContext();
         var repository = new BaseRepository<TestDbContext, TestEntity>(context);
 
-        repository.BulkInsertAsync(entities).Wait();
+        repository.BulkInsertAsync(entities).Wait(TestContext.CancellationTokenSource.Token);
         _ = context.SaveChanges();
 
         // Act
@@ -202,13 +204,13 @@ public class BaseRepositoryTests
         var repository = new BaseRepository<TestDbContext, TestEntity>(context);
 
         _ = await repository.AddAsync(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         entity.Name = "Updated Name";
 
         // Act
         var updatedEntity = repository.Update(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
         var retrievedEntity = await repository.GetByIdAsync(entity.Id);
 
         // Assert
@@ -230,7 +232,7 @@ public class BaseRepositoryTests
         var repository = new BaseRepository<TestDbContext, TestEntity>(context);
 
         _ = await repository.AddAsync(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
 
         _ = context.Attach(entity);
         context.Entry(entity).State = EntityState.Detached;
@@ -239,7 +241,7 @@ public class BaseRepositoryTests
 
         // Act
         var updatedEntity = repository.Update(entity);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
         var retrievedEntity = await repository.GetByIdAsync(entity.Id);
 
         // Assert
@@ -265,7 +267,7 @@ public class BaseRepositoryTests
 
         using var context = CreateContext();
         context.TestEntities.AddRange(entities);
-        _ = await context.SaveChangesAsync();
+        _ = await context.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
         var repository = new BaseRepository<TestDbContext, TestEntity>(context);
 
         // Act

--- a/InvoiceReminder.JobScheduler.UnitTests/HostedService/QuartzHostedServiceTests.cs
+++ b/InvoiceReminder.JobScheduler.UnitTests/HostedService/QuartzHostedServiceTests.cs
@@ -26,7 +26,7 @@ public class QuartzHostedServiceTests
         _schedules = [];
 
         _ = _schedulerFactory.GetScheduler(Arg.Any<CancellationToken>()).Returns(_scheduler);
-        _ = _schedulerFactory.GetScheduler().Returns(_scheduler);
+        _ = _schedulerFactory.GetScheduler(Arg.Any<CancellationToken>()).Returns(_scheduler);
     }
 
     [TestMethod]
@@ -41,11 +41,11 @@ public class QuartzHostedServiceTests
 
         // Assert
         _ = _scheduler.Received(1).ScheduleJob(Arg.Is<IJobDetail>(j => j.Key.Name == $"{schedule.Id}.job"),
-            Arg.Is<ITrigger>(t => t.Key.Name == $"{schedule.Id}.trigger"));
+            Arg.Is<ITrigger>(t => t.Key.Name == $"{schedule.Id}.trigger"), Arg.Any<CancellationToken>());
 
         _scheduler.Received(1).JobFactory = Arg.Is(_jobFactory);
 
-        await _scheduler.Received(1).Start();
+        await _scheduler.Received(1).Start(Arg.Any<CancellationToken>());
     }
 
     [TestMethod]
@@ -65,7 +65,7 @@ public class QuartzHostedServiceTests
         var schedule = new JobSchedule { Id = Guid.NewGuid(), CronExpression = "0 0 * * * ?", UserId = Guid.NewGuid() };
         var service = new QuartzHostedService(_logger, _schedulerFactory, _jobFactory, _schedules);
 
-        _ = _scheduler.CheckExists(Arg.Any<JobKey>()).Returns(true);
+        _ = _scheduler.CheckExists(Arg.Any<JobKey>(), Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
         await service.ReScheduleJobAsync(schedule);
@@ -75,11 +75,11 @@ public class QuartzHostedServiceTests
             Arg.Any<CancellationToken>());
 
         _ = _scheduler.Received(1).ScheduleJob(Arg.Is<IJobDetail>(j => j.Key.Name == $"{schedule.Id}.job"),
-            Arg.Is<ITrigger>(t => t.Key.Name == $"{schedule.Id}.trigger"));
+            Arg.Is<ITrigger>(t => t.Key.Name == $"{schedule.Id}.trigger"), Arg.Any<CancellationToken>());
 
         _scheduler.Received(1).JobFactory = Arg.Is(_jobFactory);
 
-        await _scheduler.Received(1).Start();
+        await _scheduler.Received(1).Start(Arg.Any<CancellationToken>());
     }
 
     [TestMethod]
@@ -89,7 +89,7 @@ public class QuartzHostedServiceTests
         var schedule = new JobSchedule { Id = Guid.NewGuid(), CronExpression = "0 0 * * * ?", UserId = Guid.NewGuid() };
         var service = new QuartzHostedService(_logger, _schedulerFactory, _jobFactory, _schedules);
 
-        _ = _scheduler.CheckExists(Arg.Any<JobKey>()).Returns(false);
+        _ = _scheduler.CheckExists(Arg.Any<JobKey>(), Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
         await service.ReScheduleJobAsync(schedule);
@@ -98,11 +98,11 @@ public class QuartzHostedServiceTests
         _ = _scheduler.DidNotReceive().DeleteJob(Arg.Any<JobKey>(), Arg.Any<CancellationToken>());
 
         _ = _scheduler.Received(1).ScheduleJob(Arg.Is<IJobDetail>(j => j.Key.Name == $"{schedule.Id}.job"),
-            Arg.Is<ITrigger>(t => t.Key.Name == $"{schedule.Id}.trigger"));
+            Arg.Is<ITrigger>(t => t.Key.Name == $"{schedule.Id}.trigger"), Arg.Any<CancellationToken>());
 
         _scheduler.Received(1).JobFactory = Arg.Is(_jobFactory);
 
-        await _scheduler.Received(1).Start();
+        await _scheduler.Received(1).Start(Arg.Any<CancellationToken>());
     }
 
     [TestMethod]
@@ -183,9 +183,9 @@ public class QuartzHostedServiceTests
         await service.ResumeJobAsync(schedule);
 
         // Assert
-        _ = _scheduler.Received(1).ResumeJob(Arg.Is<JobKey>(k => k.Name == $"{schedule.Id}.job"));
+        _ = _scheduler.Received(1).ResumeJob(Arg.Is<JobKey>(k => k.Name == $"{schedule.Id}.job"), Arg.Any<CancellationToken>());
 
-        _ = _scheduler.Received(1).ResumeTrigger(Arg.Is<TriggerKey>(k => k.Name == $"{schedule.Id}.trigger"));
+        _ = _scheduler.Received(1).ResumeTrigger(Arg.Is<TriggerKey>(k => k.Name == $"{schedule.Id}.trigger"), Arg.Any<CancellationToken>());
 
         _scheduler.Received(1).JobFactory = Arg.Is(_jobFactory);
     }
@@ -239,7 +239,8 @@ public class QuartzHostedServiceTests
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString() == "Starting Job raised an Excepetion: invalid cron"),
             Arg.Any<SchedulerException>(),
-            Arg.Any<Func<object, Exception, string>>());
+            Arg.Any<Func<object, Exception, string>>()
+        );
 
         _scheduler.Received(1).JobFactory = Arg.Is(_jobFactory);
     }


### PR DESCRIPTION
Ensures tests pass cancellation token to async methods. This allows to properly cancel running tests in case of timeout or other issues.
